### PR TITLE
fix: use maxGraphemes to enforce 1-character limit instead of maxLength

### DIFF
--- a/schema/blue.moji/collection/item.json
+++ b/schema/blue.moji/collection/item.json
@@ -29,7 +29,7 @@
             "refs": ["com.atproto.label.defs#selfLabels"]
           },
           "copyOf": { "type": "string", "format": "at-uri" },
-          "fallbackText": { "type": "string", "maxLength": 1, "default": "◌" }
+          "fallbackText": { "type": "string", "maxLength": 10, "maxGraphemes": 1, "default": "◌" }
         }
       }
     },


### PR DESCRIPTION
The default placeholder text (`◌`) takes up 3 UTF-8 bytes, not 1 (but it is true for UTF-16)

Instead of using `maxLength` we should be using `maxGrapehemes` instead to enforce `fallbackText` being 1 character.